### PR TITLE
Add support for millisecond exif timestamps

### DIFF
--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -10,8 +10,9 @@ class Metadata {
         'exif:DateTimeDigitized'
     ];
     const EXIF_FORMATS = [
-        'Y-m-d_G:i:s' => '/\d+\-\d+\-\d+_\d+:\d+:\d+/',
-        'Y:m:d G:i:s' => '/\d+\:\d+\:\d+ \d+:\d+:\d+/'
+        'Y-m-d_G:i:s' => '/^\d+\-\d+\-\d+_\d+:\d+:\d+$/',
+        'Y:m:d G:i:s' => '/^\d+\:\d+\:\d+ \d+:\d+:\d+$/',
+        'Y:m:d G:i:s.v' => '/^\d+\:\d+\:\d+ \d+:\d+:\d+\.\d+$/'
     ];
 
     static array $cache = [];


### PR DESCRIPTION
Encountered exif timestamps with millisecond precision, this causes failure. Add support for the milliseconds. Note:
* Does not begin to attempt support for microseconds, etc.
* Does not handle the dash and underscore time formats. Should look up what exif says is a valid format...