### PR TITLE
fix: add missing comma in config array

### DIFF
--- a/gp2nc.php
+++ b/gp2nc.php
@@ -44,7 +44,7 @@ $client = new Sabre\DAV\Client([
     'driver' => 'webdav',
     'baseUri' => NEXTCLOUD_URL,
     'userName' => NEXTCLOUD_USER,
-    'password' => NEXTCLOUD_PASSWORD
+    'password' => NEXTCLOUD_PASSWORD,
     'pathPrefix' => 'remote.php/dav',
     'authType' => 1, //Basic authentication
         ]);


### PR DESCRIPTION
Add the missing comma after 'password' in the config array. This fixes the PHP parse error introduced in the previous commit, that added new entries to the array. 