### PR TITLE
Fix WebDAV stream rewind error

### DIFF
--- a/src/RemoteFile.php
+++ b/src/RemoteFile.php
@@ -7,8 +7,11 @@ class RemoteFile {
 
     static function upload(callable $attempt, string $source, string $target): bool {
         $local_size = filesize($source);
+        
+        // Read file content into memory to avoid stream rewind issues
+        $file_content = file_get_contents($source);
 
-        $response = $attempt('request', 'PUT', $target, fopen($source, 'r+'), [
+        $response = $attempt('request', 'PUT', $target, $file_content, [
             'X-OC-MTime' => filemtime($source),
             'X-OC-CTime' => Metadata::takenTime($source)->getTimestamp(),
             'OC-Total-Length' => $local_size

--- a/src/RemoteFile.php
+++ b/src/RemoteFile.php
@@ -8,14 +8,22 @@ class RemoteFile {
     static function upload(callable $attempt, string $source, string $target): bool {
         $local_size = filesize($source);
         
-        // Read file content into memory to avoid stream rewind issues
-        $file_content = file_get_contents($source);
+        // Use streaming with rewind fix
+        $file_handle = fopen($source, 'rb');
+        if ($file_handle === false) {
+            throw new \Exception('Could not open source file');
+        }
+        
+        // Ensure we're at the beginning of the file
+        rewind($file_handle);
 
-        $response = $attempt('request', 'PUT', $target, $file_content, [
+        $response = $attempt('request', 'PUT', $target, $file_handle, [
             'X-OC-MTime' => filemtime($source),
             'X-OC-CTime' => Metadata::takenTime($source)->getTimestamp(),
             'OC-Total-Length' => $local_size
         ]);
+        
+        fclose($file_handle);
 
         if ($response['statusCode'] < 200 || $response['statusCode'] > 399) {
             throw new \Exception('Upload failed, invalid response code (' . $response['statusCode'] . ') received');


### PR DESCRIPTION
Fixes the WebDAV stream rewind error by using `'rb'` read mode and `rewind`.

Fixes: #22.