### PR TITLE
Get metadata before file stream open

### DIFF
--- a/src/RemoteFile.php
+++ b/src/RemoteFile.php
@@ -8,6 +8,10 @@ class RemoteFile {
     static function upload(callable $attempt, string $source, string $target): bool {
         $local_size = filesize($source);
         
+        $mtime = filemtime($source);
+        // resolve BEFORE opening stream
+        $ctime = Metadata::takenTime($source)->getTimestamp();
+
         // Use streaming with rewind fix
         $file_handle = fopen($source, 'rb');
         if ($file_handle === false) {
@@ -18,8 +22,8 @@ class RemoteFile {
         rewind($file_handle);
 
         $response = $attempt('request', 'PUT', $target, $file_handle, [
-            'X-OC-MTime' => filemtime($source),
-            'X-OC-CTime' => Metadata::takenTime($source)->getTimestamp(),
+            'X-OC-MTime' => $mtime,
+            'X-OC-CTime' => $ctime,
             'OC-Total-Length' => $local_size
         ]);
         


### PR DESCRIPTION
I ran into the following bugs in the photo folders:

```
Failed reading metadata: necessary data rewind wasn't possible
/app/vendor/sabre/http/lib/Client.php@325
#0 /app/vendor/sabre/http/lib/Client.php(114): Sabre\HTTP\Client->doRequest(Object(Sabre\HTTP\Request))
#1 /app/vendor/sabre/dav/lib/DAV/Client.php(423): Sabre\HTTP\Client->send(Object(Sabre\HTTP\Request))
#2 /app/src/Attempt.php(20): Sabre\DAV\Client->request('PUT', 'https://hed...', Resource id #194, Array)
#3 /app/src/RemoteFile.php(11): Rikmeijer\Googlephotos2nextcloud\Attempt->__invoke('request', 'PUT', '/remote.php/dav...', Resource id #194, Array)
#4 /app/src/DirectoryTask.php(128): Rikmeijer\Googlephotos2nextcloud\RemoteFile::upload(Object(Rikmeijer\Googlephotos2nextcloud\Attempt), '/photos/Algarve...', '/remote.php/dav...')
#5 /app/gp2nc.php(127): Rikmeijer\Googlephotos2nextcloud\DirectoryTask->__invoke('/photos/...')
#6 {main}
 
```

- Metadata::takenTime($source) is called inside the headers array, after the file handle is already passed as the body
- If Sabre's HTTP client reads the stream to calculate content length or for any pre-flight reason before actually sending, and then retries due to an auth challenge, the stream position is at the end and can't be rewound because Sabre has already consumed it.