### PR TITLE
✨ Add support for Live/Motion photos

### DIFF
--- a/gp2nc.php
+++ b/gp2nc.php
@@ -136,3 +136,4 @@ foreach (glob(WORKING_DIRECTORY . '/*') as $path) {
 
     $task($path);
 }
+IO::write('Done!');

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -14,52 +14,102 @@ class Metadata {
         'Y:m:d G:i:s' => '/^\d+\:\d+\:\d+ \d+:\d+:\d+$/',
         'Y:m:d G:i:s.v' => '/^\d+\:\d+\:\d+ \d+:\d+:\d+\.\d+$/'
     ];
+    const MOTION_VIDEO_EXTENSIONS = ['MP4', 'MOV'];
+    const COMPANION_IMAGE_EXTENSIONS = ['JPG', 'JPEG', 'HEIC', 'HEIF'];
 
     static array $cache = [];
+
+    static function metadataTimestamp(string $path, string $filename_for_logging): ?int {
+        $path_info = pathinfo($path);
+        $ext = $path_info['extension'] ?? '';
+        $basename = ($path_info['dirname'] ?? '.') . '/' . ($path_info['filename'] ?? basename($path));
+
+        $options = glob($path . '*.json');
+        if (preg_match('/([^\(]+)(\(\d+\))$/', $basename, $matches) > 0) {
+            $original_filename = rtrim($matches[1]) . '.' . $ext;
+            if (file_exists($original_filename) === false) {
+                IO::write('[' . $filename_for_logging . '] - ' . 'Possible duplicate of `' . basename($original_filename) . '` in filename, but original file missing');
+            } elseif (filesize($path) === filesize($original_filename)) {
+                IO::write('[' . $filename_for_logging . '] - ' . 'Duplicate of `' . basename($original_filename) . '`, try to find additional metadata files: ' . $original_filename . '.*' . $matches[2] . '.json');
+                $options = array_merge($options, glob($matches[1] . '.' . $ext . '*' . $matches[2] . '.json'));
+            } else {
+                IO::write('[' . $filename_for_logging . '] - ' . 'Possible duplicate of `' . basename($original_filename) . '` in filename, but filesize mismatch');
+                $options = glob($matches[1] . '.' . $ext . '*' . $matches[2] . '.json');
+            }
+        }
+
+        if (count($options) === 0) {
+            IO::write('[' . $filename_for_logging . '] - ' . 'No metadata files found');
+            return null;
+        }
+
+        foreach ($options as $option) {
+            if (is_file($option) === false) {
+                continue;
+            }
+
+            $photo_metadata = IO::readJson($option);
+            if (isset($photo_metadata['photoTakenTime'])) {
+                IO::write('[' . $filename_for_logging . '] - ' . 'Found `photoTakenTime` in metadata');
+                return (int) $photo_metadata['photoTakenTime']['timestamp'];
+            }
+
+            if (isset($photo_metadata['creationTime'])) {
+                IO::write('[' . $filename_for_logging . '] - ' . 'Found `creationTime` in metadata');
+                return (int) $photo_metadata['creationTime']['timestamp'];
+            }
+
+            IO::write('[' . $filename_for_logging . '] - ' . 'Found no datetime in metadata');
+        }
+
+        return null;
+    }
+
+    static function takenTimeFromCompanionImageMetadata(string $video_path, string $video_filename): ?\DateTimeImmutable {
+        $path_info = pathinfo($video_path);
+        $dirname = $path_info['dirname'] ?? '.';
+        $filename = $path_info['filename'] ?? basename($video_path);
+
+        $companion_image_paths = [];
+        foreach (self::COMPANION_IMAGE_EXTENSIONS as $companion_ext) {
+            foreach ([$companion_ext, strtolower($companion_ext)] as $ext_option) {
+                $companion_path = $dirname . '/' . $filename . '.' . $ext_option;
+                if (is_file($companion_path)) {
+                    $companion_image_paths[] = $companion_path;
+                }
+            }
+        }
+
+        $companion_image_paths = array_values(array_unique($companion_image_paths));
+        foreach ($companion_image_paths as $companion_image_path) {
+            $companion_metadata_timestamp = self::metadataTimestamp($companion_image_path, $video_filename);
+            if ($companion_metadata_timestamp === null) {
+                continue;
+            }
+
+            IO::write('[' . $video_filename . '] - ' . 'Using metadata from companion image `' . basename($companion_image_path) . '`');
+            return new \DateTimeImmutable('@' . $companion_metadata_timestamp);
+        }
+
+        return null;
+    }
 
     static function takenTime(string $photo_path): \DateTimeImmutable {
         if (isset(self::$cache[$photo_path])) {
             return self::$cache[$photo_path];
         }
 
-        list($ext, $basename) = array_map('strrev', explode('.', strrev($photo_path), 2));
-
         $photo_filename = basename($photo_path);
-        $options = glob($photo_path . '*.json');
-        if (preg_match('/([^\(]+)(\(\d+\))$/', $basename, $matches) > 0) {
-            $original_filename = rtrim($matches[1]) . '.' . $ext;
-            if (file_exists($original_filename) === false) {
-                IO::write('[' . $photo_filename . '] - ' . 'Possible duplicate of `' . basename($original_filename) . '` in filename, but original file missing');
-            } elseif (filesize($photo_path) === filesize($original_filename)) {
-                IO::write('[' . $photo_filename . '] - ' . 'Duplicate of `' . basename($original_filename) . '`, try to find additional metadata files: ' . $original_filename . '.*' . $matches[2] . '.json');
-                $options = array_merge($options, glob($matches[1] . '.' . $ext . '*' . $matches[2] . '.json'));
-            } else {
-                IO::write('[' . $photo_filename . '] - ' . 'Possible duplicate of `' . basename($original_filename) . '` in filename, but filesize mismatch');
-                $options = glob($matches[1] . '.' . $ext . '*' . $matches[2] . '.json');
-            }
+        $photo_metadata_timestamp = self::metadataTimestamp($photo_path, $photo_filename);
+        if ($photo_metadata_timestamp !== null) {
+            return self::$cache[$photo_path] = new \DateTimeImmutable('@' . $photo_metadata_timestamp);
         }
 
-        if (count($options) === 0) {
-            IO::write('[' . $photo_filename . '] - ' . 'No metadata files found');
-        } else {
-            foreach ($options as $option) {
-                if (is_file($option) === false) {
-                    continue;
-                }
-
-                $photo_metadata = IO::readJson($option);
-                if (isset($photo_metadata['photoTakenTime'])) {
-                    IO::write('[' . $photo_filename . '] - ' . 'Found `photoTakenTime` in metadata');
-                    $photo_takentime = $photo_metadata['photoTakenTime']['timestamp'];
-                } elseif (isset($photo_metadata['creationTime'])) {
-                    IO::write('[' . $photo_filename . '] - ' . 'Found `creationTime` in metadata');
-                    $photo_takentime = $photo_metadata['creationTime']['timestamp'];
-                } else {
-                    IO::write('[' . $photo_filename . '] - ' . 'Found no datetime in metadata');
-                    continue;
-                }
-
-                return self::$cache[$photo_path] = new \DateTimeImmutable('@' . $photo_takentime);
+        $photo_extension = strtoupper(pathinfo($photo_path, PATHINFO_EXTENSION));
+        if (in_array($photo_extension, self::MOTION_VIDEO_EXTENSIONS, true)) {
+            $companion_taken_time = self::takenTimeFromCompanionImageMetadata($photo_path, $photo_filename);
+            if ($companion_taken_time !== null) {
+                return self::$cache[$photo_path] = $companion_taken_time;
             }
         }
 


### PR DESCRIPTION
This is generally assuming that live/motion photos are using the same prefix as the photo. I'm validating this on my own export, since I was getting a lot of photos showing up for today's date (luckily I am starting with this archive, so I didn't have to sift through too much)

Disclosure: I used Copilot to do the bulk of the coding here, I did check the output (I'm not a PHP pro) and have run this myself to test.

Fixes #28