### PR TITLE
Fix German Takeout locale detection and missing oc-checksum header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,6 @@ COPY --from=composer /usr/bin/composer /usr/bin/composer
 RUN ["composer", "--no-dev", "install"]
 
 WORKDIR "/photos"
-ENTRYPOINT [ "php", "/app/gp2nc.php" ]
+ENTRYPOINT [ "php" ]
+CMD [ "/app/gp2nc.php" ]
 

--- a/gp2nc.php
+++ b/gp2nc.php
@@ -23,7 +23,7 @@ $parsed_url = parse_url($_ENV['NEXTCLOUD_URL']);
 
 $origin = [$parsed_url['scheme'] . '://', $parsed_url['host']];
 if (isset($parsed_url['port'])) {
-    $origin[] = $parsed_url['port'];
+    $origin[] = ':' . $parsed_url['port'];
 }
 define('NEXTCLOUD_URL', implode($origin) . '/');
 IO::write('Working on ' . NEXTCLOUD_URL);
@@ -68,7 +68,7 @@ foreach ($user_albums_metadata_files as $user_albums_metadata_file) {
     if (isset($user_album_metadata['title']) === false) {
         continue;
     } elseif (empty($user_album_metadata['title']) === false) {
-        $user_albums[] = $user_album_metadata['title'];
+        $user_albums[] = str_replace('/', '-', $user_album_metadata['title']);
     } else {
         $user_albums[] = $user_album_name;
     }

--- a/gp2nc.php
+++ b/gp2nc.php
@@ -58,7 +58,10 @@ $client = new Sabre\DAV\Client([
 
 
 $user_albums = [];
-$user_albums_metadata_files = glob(WORKING_DIRECTORY . "/*/metadata.json");
+$user_albums_metadata_files = array_merge(
+    glob(WORKING_DIRECTORY . "/*/metadata.json") ?: [],
+    glob(WORKING_DIRECTORY . "/*/Metadaten.json") ?: []
+);
 foreach ($user_albums_metadata_files as $user_albums_metadata_file) {
     $user_album_name = basename(dirname($user_albums_metadata_file));
     $user_album_metadata = IO::readJson($user_albums_metadata_file);

--- a/src/Attempt.php
+++ b/src/Attempt.php
@@ -18,7 +18,7 @@ class Attempt {
             $attempts++;
             try {
                 return $this->client->$method(...$args);
-            } catch (Sabre\HTTP\ClientException $e) {
+            } catch (\Sabre\HTTP\ClientException $e) {
                 if ($attempts === 5) {
                     throw $e;
                 } else {

--- a/src/Hash.php
+++ b/src/Hash.php
@@ -19,7 +19,7 @@ class Hash {
         $file = $attempt('request', 'HEAD', $file_path, headers: [
             'X-Hash' => 'md5'
         ]);
-        foreach ($file['headers']['oc-checksum'] as $checksum) {
+        foreach ($file['headers']['oc-checksum'] ?? [] as $checksum) {
             list($algo, $hash) = explode(':', $checksum, 2);
             if (strcasecmp($algo, 'md5') === 0) {
                 return $hash;

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -39,6 +39,17 @@ class Metadata {
             }
         }
 
+        if (count($options) === 0 && strtolower($ext) === 'mp4') {
+            // Live Photo: MP4 motion clip shares metadata with its HEIC/JPG companion
+            foreach (['HEIC', 'heic', 'JPG', 'jpg', 'JPEG', 'jpeg'] as $companion_ext) {
+                $companion_options = glob($basename . '.' . $companion_ext . '*.json') ?: [];
+                if (count($companion_options) > 0) {
+                    $options = $companion_options;
+                    break;
+                }
+            }
+        }
+
         if (count($options) === 0) {
             IO::write('[' . $photo_filename . '] - ' . 'No metadata files found');
         } else {


### PR DESCRIPTION
I was having some issues when transferring my  girlfriends takeout.

Problem 1 - German Takeout exports use Metadaten.json

Google Takeout localizes the album metadata filename. German exports name it Metadaten.json instead of metadata.json. the existing glob("*/metadata.json") matched nothing, causing the script to find 0 albums and skip all album creation/linking in Nextcloud.

Fix: Added additional glob pattern so the script works also for german locale

Problem 2 - oc-checksum header not always returned

When Nextcloud does not return an OC-Checksum header in response to the HEAD request in Hash::retrieve(), $file['headers']['oc-checksum'] is null, producing two PHP warnings and causing foreach to fail. The function already returns null as a fallback at the end, so add a coalesce guard ?? [] so the loop is simply skipped and null is returned cleanly when the header is absent.