### PR TITLE
German Takeout locale, Live Photo metadata, and several reliability issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,6 @@ COPY --from=composer /usr/bin/composer /usr/bin/composer
 RUN ["composer", "--no-dev", "install"]
 
 WORKDIR "/photos"
-ENTRYPOINT [ "php", "/app/gp2nc.php" ]
+ENTRYPOINT [ "php" ]
+CMD [ "/app/gp2nc.php" ]
 

--- a/gp2nc.php
+++ b/gp2nc.php
@@ -23,7 +23,7 @@ $parsed_url = parse_url($_ENV['NEXTCLOUD_URL']);
 
 $origin = [$parsed_url['scheme'] . '://', $parsed_url['host']];
 if (isset($parsed_url['port'])) {
-    $origin[] = $parsed_url['port'];
+    $origin[] = ':' . $parsed_url['port'];
 }
 define('NEXTCLOUD_URL', implode($origin) . '/');
 IO::write('Working on ' . NEXTCLOUD_URL);
@@ -68,7 +68,7 @@ foreach ($user_albums_metadata_files as $user_albums_metadata_file) {
     if (isset($user_album_metadata['title']) === false) {
         continue;
     } elseif (empty($user_album_metadata['title']) === false) {
-        $user_albums[] = $user_album_metadata['title'];
+        $user_albums[] = str_replace('/', '-', $user_album_metadata['title']);
     } else {
         $user_albums[] = $user_album_name;
     }

--- a/gp2nc.php
+++ b/gp2nc.php
@@ -58,7 +58,10 @@ $client = new Sabre\DAV\Client([
 
 
 $user_albums = [];
-$user_albums_metadata_files = glob(WORKING_DIRECTORY . "/*/metadata.json");
+$user_albums_metadata_files = array_merge(
+    glob(WORKING_DIRECTORY . "/*/metadata.json") ?: [],
+    glob(WORKING_DIRECTORY . "/*/Metadaten.json") ?: []
+);
 foreach ($user_albums_metadata_files as $user_albums_metadata_file) {
     $user_album_name = basename(dirname($user_albums_metadata_file));
     $user_album_metadata = IO::readJson($user_albums_metadata_file);

--- a/src/Attempt.php
+++ b/src/Attempt.php
@@ -18,7 +18,7 @@ class Attempt {
             $attempts++;
             try {
                 return $this->client->$method(...$args);
-            } catch (Sabre\HTTP\ClientException $e) {
+            } catch (\Sabre\HTTP\ClientException $e) {
                 if ($attempts === 5) {
                     throw $e;
                 } else {

--- a/src/Hash.php
+++ b/src/Hash.php
@@ -19,7 +19,7 @@ class Hash {
         $file = $attempt('request', 'HEAD', $file_path, headers: [
             'X-Hash' => 'md5'
         ]);
-        foreach ($file['headers']['oc-checksum'] as $checksum) {
+        foreach ($file['headers']['oc-checksum'] ?? [] as $checksum) {
             list($algo, $hash) = explode(':', $checksum, 2);
             if (strcasecmp($algo, 'md5') === 0) {
                 return $hash;

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -39,6 +39,17 @@ class Metadata {
             }
         }
 
+        if (count($options) === 0 && strtolower($ext) === 'mp4') {
+            // Live Photo: MP4 motion clip shares metadata with its HEIC/JPG companion
+            foreach (['HEIC', 'heic', 'JPG', 'jpg', 'JPEG', 'jpeg'] as $companion_ext) {
+                $companion_options = glob($basename . '.' . $companion_ext . '*.json') ?: [];
+                if (count($companion_options) > 0) {
+                    $options = $companion_options;
+                    break;
+                }
+            }
+        }
+
         if (count($options) === 0) {
             IO::write('[' . $photo_filename . '] - ' . 'No metadata files found');
         } else {


### PR DESCRIPTION
I was having some issues when transferring my girlfriends takeout, and some of the issues I had encountered before with my own but had only fixed locally. 

German Takeout locale: Google Takeout exports album metadata as Metadaten.json in German locales. The script was only looking for metadata.json (case-sensitive on Linux), finding 0 albums and skipping all album creation and photo linking.

Album titles with /: Album titles containing a forward slash (e.g. "Madeira 2023/24") caused rawurlencode to produce %2F, which WebDAV servers decode back to a path separator, silently failing the MKCOL. The title is now normalised (/ → -) to match the filesystem directory name and produce a valid WebDAV path.

Live Photo MP4s missing metadata: iPhone Live Photos export as a HEIC+MP4 pair, but Google Takeout only writes one sidecar JSON (attached to the HEIC). The MP4 had no sidecar of its own, causing it to fall back to filemtime (the Takeout extraction date) and be filed in the wrong year/month folder. Metadata::takenTime() now checks for a same-named HEIC/JPG companion sidecar when an MP4 has no own sidecar, covering both upper- and lowercase file extensions.

Attempt retry logic never fired: catch (Sabre\HTTP\ClientException $e) inside the Rikmeijer\Googlephotos2nextcloud namespace resolved to a non-existent class, so every Sabre\HTTP\ClientException (including transient network errors like "necessary data rewind was not possible") propagated immediately instead of being retried. Added the missing leading \.

oc-checksum header not always returned: When Nextcloud does not return an OC-Checksum header in response to the HEAD request in Hash::retrieve(), iterating over null produced two PHP warnings and aborted the hash lookup. Added ?? [] guard.

Port number missing colon in URL construction: implode() on the origin array produced host8080 instead of host:8080 when a port was present.

Dockerfile: Split ENTRYPOINT/CMD so additional scripts (e.g. repair utilities) can be invoked by passing the script path as an argument, I had a local one off script to fix some of the incorrect timestamps in live photos that I wanted to run. In this case it is of no use unless additional functions would be added.

Test plan

- [ ]  Run with a German-locale Takeout export and verify albums are detected and created
- [ ]  Verify "New York 2023/24"-style albums are created and photos linked correctly
- [ ]  Confirm Live Photo MP4s are filed under the HEIC's taken date, not extraction date
- [ ]  Simulate a network drop mid-run and confirm retry fires instead of crashing
- [ ]  Confirm no PHP warnings when OC-Checksum header is absent